### PR TITLE
Make is_debug() and is_release() const, and implement Display rather than ToString

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,29 +1,31 @@
+use std::fmt::Display;
+
 #[derive(Debug, PartialEq)]
 pub enum BuildModel {
     Debug,
     Release,
 }
 
-pub fn build_channel() -> BuildModel {
+pub const fn build_channel() -> BuildModel {
     if cfg!(debug_assertions) {
         return BuildModel::Debug;
     }
     BuildModel::Release
 }
 
-impl ToString for BuildModel {
-    fn to_string(&self) -> String {
+impl Display for BuildModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Debug => "debug".to_string(),
-            Self::Release => "release".to_string(),
+            Self::Debug => f.write_str("debug"),
+            Self::Release => f.write_str("release"),
         }
     }
 }
 
-pub fn is_debug() -> bool {
-    build_channel() == BuildModel::Debug
+pub const fn is_debug() -> bool {
+    matches!(build_channel(), BuildModel::Debug)
 }
 
-pub fn is_release() -> bool {
-    build_channel() == BuildModel::Release
+pub const fn is_release() -> bool {
+    matches!(build_channel(), BuildModel::Release)
 }


### PR DESCRIPTION
Thanks for this! I was looking to use these functions in a const context (via shadow-rs), and noticed that they where not const.

This PR makes them const, and also implements Display over ToString (you get a ToString implementation from Display).